### PR TITLE
Add GitHub Actions Workflow

### DIFF
--- a/.github/workflows/stuffbin.yml
+++ b/.github/workflows/stuffbin.yml
@@ -1,0 +1,101 @@
+name: Test and Build
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        go: [1.11, 1.12, 1.13]
+    name: ${{ matrix.os }} @ Go ${{ matrix.go }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Setup Go ${{ matrix.go }}
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Set GOPATH, PATH and ENV
+        run: |
+          echo "::set-env name=GOPATH::$(dirname $GITHUB_WORKSPACE)"
+          echo "::set-env name=GO111MODULE::on"
+          echo "::set-env name=GOPROXY::https://proxy.golang.org"
+          echo "::add-path::$(dirname $GITHUB_WORKSPACE)/bin"
+        shell: bash
+
+      - name: Checkout Code
+        uses: actions/checkout@v1
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Run Tests
+        run: go test ./...
+
+      - name: Extract Version
+        if: success() && contains(github.ref, 'v') && matrix.os == 'ubuntu-latest' && matrix.go == '1.13'
+        id: extract_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+
+      - name: Build Binary
+        if: success() && contains(github.ref, 'v') && matrix.os == 'ubuntu-latest' && matrix.go == '1.13'
+        run: |
+          GOOS=linux go build -o stuffbin-linux-amd64-${{ steps.extract_version.outputs.VERSION }}/stuffbin -ldflags "-s -w" stuffbin/main.go
+          tar -czvf stuffbin-linux-amd64-${{ steps.extract_version.outputs.VERSION }}.tar.gz stuffbin-linux-amd64-${{ steps.extract_version.outputs.VERSION }}
+          GOOS=darwin go build -o stuffbin-macos-amd64-${{ steps.extract_version.outputs.VERSION }}/stuffbin -ldflags "-s -w" stuffbin/main.go
+          tar -czvf stuffbin-macos-amd64-${{ steps.extract_version.outputs.VERSION }}.tar.gz stuffbin-macos-amd64-${{ steps.extract_version.outputs.VERSION }}
+          GOOS=windows go build -o stuffbin-windows-amd64-${{ steps.extract_version.outputs.VERSION }}/stuffbin.exe -ldflags "-s -w" stuffbin/main.go
+          tar -czvf stuffbin-windows-amd64-${{ steps.extract_version.outputs.VERSION }}.tar.gz stuffbin-windows-amd64-${{ steps.extract_version.outputs.VERSION }}
+
+      - name: Create Release
+        id: create_release
+        if: success() && contains(github.ref, 'v') && matrix.os == 'ubuntu-latest' && matrix.go == '1.13'
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Linux Asset to Release
+        if: success() && contains(github.ref, 'v') && matrix.os == 'ubuntu-latest' && matrix.go == '1.13'
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./stuffbin-linux-amd64-${{ steps.extract_version.outputs.VERSION }}.tar.gz
+          asset_name: stuffbin-linux-amd64-${{ steps.extract_version.outputs.VERSION }}.tar.gz
+          asset_content_type: application/tar+gzip
+
+      - name: Upload MacOS Asset to Release
+        if: success() && contains(github.ref, 'v') && matrix.os == 'ubuntu-latest' && matrix.go == '1.13'
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./stuffbin-macos-amd64-${{ steps.extract_version.outputs.VERSION }}.tar.gz
+          asset_name: stuffbin-macos-amd64-${{ steps.extract_version.outputs.VERSION }}.tar.gz
+          asset_content_type: application/tar+gzip
+
+      - name: Upload Windows Asset to Release
+        if: success() && contains(github.ref, 'v') && matrix.os == 'ubuntu-latest' && matrix.go == '1.13'
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./stuffbin-windows-amd64-${{ steps.extract_version.outputs.VERSION }}.tar.gz
+          asset_name: stuffbin-windows-amd64-${{ steps.extract_version.outputs.VERSION }}.tar.gz
+          asset_content_type: application/tar+gzip

--- a/fs_test.go
+++ b/fs_test.go
@@ -126,7 +126,7 @@ func TestParseTemplatesGlob(t *testing.T) {
 		},
 	}
 
-	fs, err := NewLocalFS("/", "mock/", "mock/foo.txt:/foo.txt", "mock/foofunc.txt:/foofunc.txt")
+	fs, err := NewLocalFS("/", "mock/foo.txt:/foo.txt", "mock/foofunc.txt:/foofunc.txt")
 	assert(t, "error creating local FS", nil, err)
 	if fs == nil {
 		return

--- a/unstuff_test.go
+++ b/unstuff_test.go
@@ -1,6 +1,7 @@
 package stuffbin
 
 import (
+	"runtime"
 	"sort"
 	"testing"
 )
@@ -16,13 +17,23 @@ func TestUnStuff(t *testing.T) {
 func TestGetStuff(t *testing.T) {
 	b, err := GetStuff(mockBinStuffed)
 	assert(t, "error getting stuff", nil, err)
-	assert(t, "mismatch in stuff byte size", mockZipSize, len(b))
+	expectedLength := len(b)
+	if runtime.GOOS == "windows" {
+		// reduce length by one to compensate for \r line ending byte on windows
+		expectedLength--
+	}
+	assert(t, "mismatch in stuff byte size", mockZipSize, expectedLength)
 }
 
 func TestUnzipFiles(t *testing.T) {
 	b, err := GetStuff(mockBinStuffed)
 	assert(t, "error getting stuff", nil, err)
-	assert(t, "mismatch in stuff byte size", mockZipSize, len(b))
+	expectedLength := len(b)
+	if runtime.GOOS == "windows" {
+		// reduce length by one to compensate for \r line ending byte on windows
+		expectedLength--
+	}
+	assert(t, "mismatch in stuff byte size", mockZipSize, expectedLength)
 
 	// Unzip the files and check if they're all there including
 	// the alias.


### PR DESCRIPTION
## Aim

The aim of this PR is to add support for GitHub Action for this repository. It is configured to work as described below:

1. Test cases will be run for every PR on the `master` branch. Test cases will be run on `Ubuntu`, `MacOS` and `Windows` using the three current supported versions of Go: `1.11`, `1.12` and `1.13`.

2. For every push on the `master` branch, the test cases will be run as described in point 1 above.

3. In case a tag of the format `v*` is pushed on the `master` branch, the repo will be built and the binaries for `Linux`, `MacOS` and `Windows` will be uploaded as a release.

## Changes

* `.github/workflows/stuffbin.yml` - Add support for GitHub Actions.
*  `fs_test.go` - Add only `foo.txt` and `foofunc.txt` to the glob to increase the stability of the test case.
* `stuff_test.go` - Decrement sizes for windows to compensate for the extra `\r` byte. Also, add code to the assert function to discard `\r` byte wherever applicable.
* `unstuff_test.go` - Decrement sizes for windows to compensate for the extra `\r` byte.

## Long Term Maintenance Objectives

In the long run, the Go versions would need to be updated to keep up with the currently supported versions.

## Future Enhancements

We could also potentially have a release notes generating system setup that would automate the generation of release notes for the release.