### PR TITLE
Fix ParseTemplates to create separate named templates for each file

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -282,7 +282,7 @@ func ParseTemplatesGlob(f template.FuncMap, fs FileSystem, pattern string) (*tem
 // ParseTemplates takes a file system, a list of file paths,
 // and parses them into a template.Template.
 func ParseTemplates(f template.FuncMap, fs FileSystem, path ...string) (*template.Template, error) {
-	tpl := template.New(filepath.Base(path[0]))
+	tpl := template.New("_all")
 	if f != nil {
 		tpl = tpl.Funcs(f)
 	}
@@ -297,7 +297,7 @@ func ParseTemplates(f template.FuncMap, fs FileSystem, path ...string) (*templat
 			return nil, fmt.Errorf("%s: %v", p, err)
 		}
 
-		_, err = tpl.Parse(string(f))
+		_, err = tpl.New(filepath.Base(p)).Parse(string(f))
 		if err != nil {
 			return nil, err
 		}

--- a/fs.go
+++ b/fs.go
@@ -297,6 +297,7 @@ func ParseTemplates(f template.FuncMap, fs FileSystem, path ...string) (*templat
 			return nil, fmt.Errorf("%s: %v", p, err)
 		}
 
+		// Template's name will be the full path without leading "/"
 		rel, err := filepath.Rel("/", p)
 		if err != nil {
 			return nil, err

--- a/fs.go
+++ b/fs.go
@@ -282,7 +282,7 @@ func ParseTemplatesGlob(f template.FuncMap, fs FileSystem, pattern string) (*tem
 // ParseTemplates takes a file system, a list of file paths,
 // and parses them into a template.Template.
 func ParseTemplates(f template.FuncMap, fs FileSystem, path ...string) (*template.Template, error) {
-	tpl := template.New("_all")
+	tpl := template.New("")
 	if f != nil {
 		tpl = tpl.Funcs(f)
 	}
@@ -297,7 +297,19 @@ func ParseTemplates(f template.FuncMap, fs FileSystem, path ...string) (*templat
 			return nil, fmt.Errorf("%s: %v", p, err)
 		}
 
-		_, err = tpl.New(filepath.Base(p)).Parse(string(f))
+		rel, err := filepath.Rel("/", p)
+		if err != nil {
+			return nil, err
+		}
+
+		// Parse into named template
+		_, err = tpl.New(rel).Parse(string(f))
+		if err != nil {
+			return nil, err
+		}
+
+		// Parse (append) into root template for BC
+		_, err = tpl.Parse(string(f))
 		if err != nil {
 			return nil, err
 		}

--- a/fs.go
+++ b/fs.go
@@ -308,7 +308,7 @@ func ParseTemplates(f template.FuncMap, fs FileSystem, path ...string) (*templat
 			return nil, err
 		}
 
-		// Parse (append) into root template for BC
+		// Parse into root template for BC
 		_, err = tpl.Parse(string(f))
 		if err != nil {
 			return nil, err

--- a/fs_test.go
+++ b/fs_test.go
@@ -141,6 +141,45 @@ func TestParseTemplatesGlob(t *testing.T) {
 	assert(t, "mismatch in executed template", "foo\nfoo - func\n", b.String())
 }
 
+func TestExecuteTemplate(t *testing.T) {
+	fs, err := NewLocalFS("/", "mock/:/")
+	assert(t, "error creating local FS", nil, err)
+	if fs == nil {
+		return
+	}
+
+	tpl, err := ParseTemplates(nil, fs, "/foo.txt", "/bar.txt", "/subdir/baz.txt")
+	assert(t, "error parsing template", nil, err)
+
+	b := bytes.Buffer{}
+	err = tpl.ExecuteTemplate(&b, "subdir/baz.txt", nil)
+	assert(t, "template execute failed", nil, err)
+	assert(t, "mismatch in executed template", "baz\n", b.String())
+}
+
+func TestExecuteTemplateGlob(t *testing.T) {
+	// Template func map.
+	mp := map[string]interface{}{
+		"Foo": func() string {
+			return "func"
+		},
+	}
+
+	fs, err := NewLocalFS("/", "mock/:/")
+	assert(t, "error creating local FS", nil, err)
+	if fs == nil {
+		return
+	}
+
+	tpl, err := ParseTemplatesGlob(mp, fs, "/*.txt")
+	assert(t, "error parsing template", nil, err)
+
+	b := bytes.Buffer{}
+	err = tpl.ExecuteTemplate(&b, "bar.txt", nil)
+	assert(t, "template execute failed", nil, err)
+	assert(t, "mismatch in executed template", "bar", b.String())
+}
+
 func TestMerge(t *testing.T) {
 	fs, err := NewLocalFS("/", "mock/", "mock/foo.txt:/foo.txt")
 	assert(t, "error creating local FS", nil, err)

--- a/fs_test.go
+++ b/fs_test.go
@@ -148,7 +148,7 @@ func TestExecuteTemplate(t *testing.T) {
 		return
 	}
 
-	tpl, err := ParseTemplates(nil, fs, "/foo.txt", "/bar.txt", "/subdir/baz.txt")
+	tpl, err := ParseTemplates(nil, fs, "/foo.txt", "/subdir/baz.txt", "/bar.txt")
 	assert(t, "error parsing template", nil, err)
 
 	b := bytes.Buffer{}
@@ -175,6 +175,11 @@ func TestExecuteTemplateGlob(t *testing.T) {
 	assert(t, "error parsing template", nil, err)
 
 	b := bytes.Buffer{}
+	err = tpl.ExecuteTemplate(&b, "foo.txt", nil)
+	assert(t, "template execute failed", nil, err)
+	assert(t, "mismatch in executed template", "foo\nfoo - func\n", b.String())
+
+	b.Reset()
 	err = tpl.ExecuteTemplate(&b, "bar.txt", nil)
 	assert(t, "template execute failed", nil, err)
 	assert(t, "mismatch in executed template", "bar", b.String())
@@ -196,7 +201,6 @@ func TestNamedTemplates(t *testing.T) {
 	}
 	sort.Strings(names)
 
-	assert(t, "template execute failed", nil, err)
 	assert(t, "mismatch in executed template", []string{"", "bar.txt", "foo.txt"}, names)
 }
 

--- a/fs_test.go
+++ b/fs_test.go
@@ -180,6 +180,26 @@ func TestExecuteTemplateGlob(t *testing.T) {
 	assert(t, "mismatch in executed template", "bar", b.String())
 }
 
+func TestNamedTemplates(t *testing.T) {
+	fs, err := NewLocalFS("/", "mock/", "mock/bar.txt:/bar.txt", "mock/foo.txt:/foo.txt")
+	assert(t, "error creating local FS", nil, err)
+	if fs == nil {
+		return
+	}
+
+	tpl, err := ParseTemplatesGlob(nil, fs, "/*.txt")
+	assert(t, "error parsing template", nil, err)
+
+	names := make([]string, len(tpl.Templates()))
+	for i, template := range tpl.Templates() {
+		names[i] = template.Name()
+	}
+	sort.Strings(names)
+
+	assert(t, "template execute failed", nil, err)
+	assert(t, "mismatch in executed template", []string{"", "bar.txt", "foo.txt"}, names)
+}
+
 func TestMerge(t *testing.T) {
 	fs, err := NewLocalFS("/", "mock/", "mock/foo.txt:/foo.txt")
 	assert(t, "error creating local FS", nil, err)


### PR DESCRIPTION
I discovered this bug via listmonk. To reproduce, edit one of the email template files, for example: `static/email-templates/campaign-status.html` to add an error such as this: (Note the missing quote after `"Name`)

```diff
 <table width="100%">
     <tr>
         <td width="30%"><strong>{{ L.Ts "globals.terms.campaign" }}</strong></td>
-        <td><a href="{{ RootURL }}/admin/campaigns/{{ index . "ID" }}">{{ index . "Name" }}</a></td>
+        <td><a href="{{ RootURL }}/admin/campaigns/{{ index . "ID" }}">{{ index . "Name }}</a></td>
     </tr>
     <tr>
```

Then, run listmonk:

```
./listmonk --static-dir=static
```

Each time you run it, you'll get a different file in the error message. This is because the name of the template (`filepath.Base(path[0])`) is different each time. 

```
2023/03/23 14:55:17 init.go:626: error parsing e-mail notif templates: template: subscriber-data.html:7: unterminated quoted string
```
```
2023/03/23 14:55:18 init.go:626: error parsing e-mail notif templates: template: import-status.html:7: unterminated quoted string
```
```
2023/03/23 14:55:19 init.go:626: error parsing e-mail notif templates: template: smtp-test.html:7: unterminated quoted string
```

Expected result is for the error to mention `campaign-status.html`. This patch fixes that.

I hope this shouldn't cause any other problems, but I haven't tested fully yet, and I'm not a go programmer.