### PR TITLE
ci: run tests in gh-actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Run Tests
+
+# Triggers the workflow on push or pull request events
+on: [push, pull_request]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        go: [ '1.18', '1.19', '1.20' ]
+
+    runs-on: ubuntu-20.04
+
+    name: Go ${{ matrix.go }} Tests
+    steps:
+      - uses: actions/checkout@v3
+ 
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Run Tests with Coverage
+        run: go test -v -cover ./...

--- a/stuffbin/main.go
+++ b/stuffbin/main.go
@@ -19,8 +19,7 @@ The file paths to embed can be suffixed by a colon and an
 target (alias) path, for instance /original/local/path:/virtual/path.
 When compressed and stuffed, the original path is overwritten
 with the alias, which in turn can be used to access the file
-from within the application.
-`
+from within the application.`
 
 var (
 	aID      = "id"


### PR DESCRIPTION
Adds a `go test` CI workflow. It'll run whenever a new commit is pushed/PR is sent.